### PR TITLE
Aligning to the left

### DIFF
--- a/layouts/partials/page-title.html
+++ b/layouts/partials/page-title.html
@@ -2,7 +2,11 @@
 <section class="page-title bg-primary position-relative overflow-hidden">
   <div class="container">
     <div class="row">
+      {{ if and (eq .Page.Type "docs") (eq .Page.Kind "page" ) }}
+      <div class="col-12 text-left">
+      {{ else }}        
       <div class="col-12 text-center">
+        {{ end }}      
         <h1 class="text-white font-tertiary">{{.Title}}</h1>
       </div>
     </div>

--- a/layouts/partials/page-title.html
+++ b/layouts/partials/page-title.html
@@ -6,7 +6,7 @@
       <div class="col-12 text-left">
       {{ else }}        
       <div class="col-12 text-center">
-        {{ end }}      
+      {{ end }}      
         <h1 class="text-white font-tertiary">{{.Title}}</h1>
       </div>
     </div>

--- a/static/sass/base/theme.scss
+++ b/static/sass/base/theme.scss
@@ -518,7 +518,7 @@ blockquote {
     right: -100px
 }
 .page-title {
-    padding: 250px 0 150px
+    padding: 130px 0 30px
 }
 .page-title .container {
     position: relative;


### PR DESCRIPTION
Reducing the size of the page title area for docs and blog posts, also aligning the page title to the left when they are individual entries in the docs

![image](https://user-images.githubusercontent.com/5992658/85888991-ef1b5e80-b7ea-11ea-9797-b8196dc46b32.png)
