### PR TITLE
Some review and modifications to the policies

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -6,13 +6,15 @@ description: "Sauce Labs Open Source Documentation"
 
 ##### Saucers have used Open Source since Day One, but there are still misconceptions and uncertainties on how to engage in Open Source. Questions on legal issues, licensing and what is deemed confidential or internal information is common.
 
-##### These documents are a principally guide for Saucers - but also serve as a reference by anyone else - on how to adopt, modify and release Open Source code. 
+##### These documents are a principally guide for Saucers - but also serve as a reference by anyone else - on how to adopt, modify and release Open Source code.
 
-> This content is inspired by Zalando's Open Source [documentation](https://opensource.zalando.com/docs), which has an [MIT license](https://github.com/zalando/zalando.github.io/blob/master/LICENSE).
+> This content is inspired by Zalando's Open Source [documentation](https://opensource.zalando.com/docs), which has an [MIT license](https://github.com/zalando/zalando.github.io/blob/master/LICENSE) as well as various of other sources. However, many of the things we do are unique to how Sauce Labs operates and our engineering culture, so these should not be read as "how-to" guides. To hear from more companies deeply involved in open source, we recommend checking out the [TODO Group](https://todogroup.org/).
 
 ### Topics
 
 - [Approval guide for managers]({{< relref "approval-guide.md" >}}) As a manager at Sauce Labs, you will from time to time be asked by your direct reports if they can make an internal codebase an open source project.
 - [Contributing to Open Source]({{< relref "contributing.md" >}}) Participation in Open Source projects is highly encouraged, and the Open Source team wants to make this process as simple as possible.
-- [Open Source Licensing Guide]({{< relref "license-guide.md" >}}) Policies and guidance on which licenses can be used at Sauce Labs, both internally and in open source projects hosted under the Sauce Labs GitHub organization.
+- [Open Source Licensing Guide]({{< relref "license-guide.md" >}}) Policies and guidance on which licenses can be used at Sauce Labs, both internally and in open source projects hosted under a Sauce Labs managed GitHub organization.
 - [Releasing a new Open Source project]({{< relref "releasing.md" >}}) Here you can see all the steps that describe how Saucers can release a new Open Source project.
+
+If any of the docs are unclear, misleading or wrong, please reach out to the [Open Source team](mailto:opensource@saucelabs.com) at Sauce Labs.

--- a/content/docs/approval-guide.md
+++ b/content/docs/approval-guide.md
@@ -8,8 +8,6 @@ As a manager at Sauce Labs, you will from time to time be asked by your direct r
 
 Also, every request to open source will be reviewed and must be approved by our Open Source Program Office (and usually in collaboration with Legal, Product, and so on). Feel free to reach out to the OSPO for advice beforehand, if you would like.
 
-> This content is inspired by Zalando's Open Source [documentation](https://opensource.zalando.com/docs), which has an [MIT license](https://github.com/zalando/zalando.github.io/blob/master/LICENSE).
-
 ### Summary
 To determine if a project can be open-sourced, you should be able to answer “yes“ to the following 3 questions, background information on each are provided in sections below:
 

--- a/content/docs/contributing.md
+++ b/content/docs/contributing.md
@@ -6,14 +6,12 @@ draft: false
 
 Participation in Open Source projects is highly encouraged, and the Open Source team wants to make this process as simple as possible. All Saucers are expected to follow common sense regarding what type of information and code is contributed to upstream Open Source projects. If you are in doubt, please reach out to the Open Source team or ask your manager for instructions.
 
-> This content is inspired by Zalando's Open Source [documentation](https://opensource.zalando.com/docs), which has an [MIT license](https://github.com/zalando/zalando.github.io/blob/master/LICENSE).
-
 ### Summary
 
 - Upstream contributions are highly encouraged
 - Double-check you are not sharing confidential information
 - Avoid contributions with information or code that gives us an advantage over competitors
-- Only sign whitelisted CLAs, reach out to the Open Source team or Legal for advice
+- Only sign whitelisted CLAs, reach out to the Open Source team for advice
 
 ### Common Contribution Rules
 - Do not share Sauce Labs confidential information
@@ -41,7 +39,7 @@ Upstream code contributions are encouraged to Open Source projects that our cust
 Both are allowed and they do not need a review unless you have questions about the contribution rules and guidelines mentioned above. Simply ensure that the project you are contributing to is not licensed under [AGPL](https://www.gnu.org/licenses/agpl-3.0.en.html).
 
 ### Whitelisted CLAs
-If a non-Sauce Labs Open Source project requires you to sign a contributor agreement, ask the Open Source team or Legal, unless it is one of the following whitelisted CLAs:
+If a non-Sauce Labs Open Source project requires you to sign a contributor agreement, ask the Open Source team, unless it is one of the following whitelisted CLAs:
 
 - Selenium Project [CLA](https://gist.github.com/selenium-ci/90e5715f953d820cf3fc6f2c22f4184c#file-selenium_project_cla)
 - Appium Project [CLA](https://cla.js.foundation/appium/appium)

--- a/content/docs/license-guide.md
+++ b/content/docs/license-guide.md
@@ -4,11 +4,9 @@ description: "Open Source Licensing Guide"
 draft: false
 ---
 
-Policies and guidance on which licenses can be used at Sauce Labs, both internally and in open source projects hosted under the Sauce Labs GitHub organization.
+Policies and guidance on which licenses can be used at Sauce Labs, both internally and in open source projects hosted under a Sauce Labs managed GitHub organization.
 
 Understanding and respecting the licenses of your project dependencies are important when using and releasing Open Source software. The purpose of this document is to outline what licenses to avoid, which ones can be freely used and which licenses come with special requirements.
-
-> This content is inspired by Zalando's Open Source [documentation](https://opensource.zalando.com/docs), which has an [MIT license](https://github.com/zalando/zalando.github.io/blob/master/LICENSE).
 
 ### Summary
 

--- a/content/docs/releasing.md
+++ b/content/docs/releasing.md
@@ -6,8 +6,6 @@ draft: false
 
 Here you can see all the steps that describe how Saucers can release a new Open Source project. This is a simple process and in case you need help to go through it, the Open Source team is here to give you a hand.
 
-> This content is inspired by Zalando's Open Source [documentation](https://opensource.zalando.com/docs), which has an [MIT license](https://github.com/zalando/zalando.github.io/blob/master/LICENSE).
-
 ### Overview
 Releasing a new open source project is a simple process, just check the following sections:
 
@@ -35,7 +33,7 @@ If you are in doubt, please reach out to the [Open Source team](https://wiki.sau
 Follow a few guidelines that are present in many of the most renowned Open Source projects, satisfy the following 3 areas and you will get your Open Source project started on the right foot.
 
 #### Include the required assets
-Use the [new-project](https://github.com/zalando-incubator/new-project) template as a boilerplate for the files required for your project. These files are needed to correctly communicate ownership and guidelines for the project:
+Use the [new-project](https://github.com/saucelabs/new-project) template as a boilerplate for the files required for your project. These files are needed to correctly communicate ownership and guidelines for the project:
 
 - Create a meaningful README.md file, this is your most important piece of documentation, it should contain:
     - Main description and purpose of your project
@@ -62,23 +60,22 @@ When the project has been released as a public project on GitHub the following w
 
 - Semantically version project artifacts. You MUST tag all versions in GitHub with the exact version name: e.g., 0.1.0
 - Make sure that no credentials, private identifiers or personal data is at any time present in your repository
-- Make sure code-reviews with by least 2 Saucers on all code to minimize the risk of implanted security backdoors and vulnerable code.
+- Make sure code-reviews with by least 1 Sauce employee on all code to minimize the risk of implanted security backdoors and vulnerable code.
 - Make sure there is an active team of maintainers of at least 2 Saucers taking ownership of the project
-- Make sure there is a continuous integration setup in place that runs all tests and measures coverage for every commit in every branch and in every pull request
-- Make sure there is a code analysis tool (like Codacy or SonarQube) checking the code health for every commit in every branch and also for all pull requests
+- Make sure there is a continuous integration setup in place that runs all linting, tests and measures coverage for every commit in every branch and in every pull request
 
 #### Community best practices
-Different Open Source projects that have been embraced by the community have a few things in common, here are some that we highly recommend you to implement:
+Different Open Source projects that have been embraced by the community have a few things in common, here are some that we require you to implement:
 
 - Have a code of conduct and enforce it to create a safe environment for collaboration
-- Set clear expectations for responses - let users know if your time is limited
+- Set clear expectations for responses - let users know (e.g. in the SUPPORT.md file) if your time is limited
 - Ask for help and be open to what kind of contributions would help your project
 - Be mindful of your documentation
 
 [opensource.guide](https://opensource.guide/building-community/) has plenty more resources and recommendations for maintainers.
 
 ### Copyright and ownership
-All code released by Saucers must be released under the Sauce Labs GitHub organization and its copyright is owned by Sauce Labs.
+All code released by Saucers must be released under a Sauce Labs managed GitHub organization and its copyright is owned by Sauce Labs.
 
 ### Prepare your repository
 Having a repository ready to be open-sourced is more than following the previous recommendations, it is also about having refactored and documented code that facilitates users and potential contributors to make sense of it. A few more things to look out are:
@@ -94,6 +91,6 @@ Having a repository ready to be open-sourced is more than following the previous
 When you have checked off the previous recommendations checklist and prepared your code for release, request a review from the Open Source team who will help you set up a GitHub repository in the Sauce Labs organization and sign off on open-sourcing your project.
 
 ### Release
-When all the above points are in order and the review has been passed, the project is released to the Sauce Labs GitHub organization. All released projects and are then reviewed over a 6 month period to double-check they are still valuable for the community.
+When all the above points are in order and the review has been passed, the project is released to a Sauce Labs managed GitHub organization. All released projects are then reviewed over a 6 month period to double-check they are still valuable for the community.
 
 As part of the release, it is highly encouraged that a blog post is drafted, where the project and its benefits for the community are described (see an example). Please coordinate with the Open Source team to get the draft completed and published.

--- a/content/docs/releasing.md
+++ b/content/docs/releasing.md
@@ -62,6 +62,9 @@ When the project has been released as a public project on GitHub the following w
 - Make sure that no credentials, private identifiers or personal data is at any time present in your repository
 - Make sure code-reviews with by least 1 Sauce employee on all code to minimize the risk of implanted security backdoors and vulnerable code.
 - Make sure there is an active team of maintainers of at least 2 Saucers taking ownership of the project
+
+We recommend to also:
+
 - Make sure there is a continuous integration setup in place that runs all linting, tests and measures coverage for every commit in every branch and in every pull request
 
 #### Community best practices


### PR DESCRIPTION
Couple of comments:

- moved the "Inspired by Zalando" note to a central place so we don't need to maintain it on several pages
- some wording changes given that we have multiple orgs

```diff
- hosted under the Sauce Labs GitHub organization.
+ hosted under a Sauce Labs managed GitHub organization.
```

- Removed Legal Council from the text as the OSPO should be the central point for questions, we ourself should reach out to Legal if necessary - this also prevents that any conversations pass by the office
- code reviews should be done by at least 1 Sauce instead of 2 - having a commit to be signed of by 2 employees seems more cumbersome than it helps, it should be possible to maintain a project with at least 2 people.
- `Community best practices` like CoC are a must, not only recommended