### PR TITLE
Fix style for strong tag

### DIFF
--- a/static/sass/base/theme.scss
+++ b/static/sass/base/theme.scss
@@ -452,10 +452,8 @@ blockquote {
     font-family: $fontFamily;
     font-weight: 400;
     color: #000;
-    display: inherit;
-    line-height: 1.5;
+    display: inline;
     list-style: none;
-    font-size: 18px;
     margin: 0;
 }
 .page-title-alt {


### PR DESCRIPTION
If we highlight something bold in markdown the text is wrapped in `strong` tags. These had a weird style setup which will be fixed by this PR.

Before:
![Screenshot 2020-07-07 at 22 47 31](https://user-images.githubusercontent.com/731337/86841396-308df280-c0a4-11ea-8f1b-e0ce633baeb6.png)

After:
![Screenshot 2020-07-07 at 22 48 16](https://user-images.githubusercontent.com/731337/86841405-32f04c80-c0a4-11ea-911f-52a03c516e4e.png)
