### PR TITLE
Do not require a Maintainers.md file

### DIFF
--- a/content/docs/releasing.md
+++ b/content/docs/releasing.md
@@ -40,15 +40,14 @@ Use the [new-project](https://github.com/saucelabs/new-project) template as a bo
     - How to install it
     - How to use it (with examples)
     - If applicable, extended documentation explaining more elaborate use cases
-- Include a MAINTAINERS.md file with contact information
 - Include a CONTRIBUTION.md file with guidelines on how to contribute, including:
     - How to set up and develop the project
     - If necessary, an explanation of code style
     - How to run and write tests
     - How to write documentation or, if applicable, how to generate it
     - A list of requirements to contribute a patch (this could also be described in a pull request [template](https://help.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates))
-- Include a CODE_OF_CONDUCT.md file with guidelines that establish expectations for behavior by participants (maintainers, contributors, users) working on your project
-- Include a SECURITY.md file
+- Include a CODE_OF_CONDUCT.md file with guidelines that establish expectations for behavior by participants (maintainers, contributors, users) working on your project (only necessary if your project has custom wording as our default [CODE_OF_CONDUCT.md](https://github.com/saucelabs/.github/blob/master/CODE_OF_CONDUCT.md))
+- Include a SECURITY.md file (only necessary if your project has special requirements for security escalations as we have a default [SECURITY.md](https://github.com/saucelabs/.github/blob/master/SECURITY.md) for all projects)
 - Add a LICENSE.md file; the license must be MIT with the copyright attributed to Sauce Labs
 - Ensure you only use license-compatible code/dependencies (see [licensing](/docs/license-guide/))
 

--- a/content/docs/releasing.md
+++ b/content/docs/releasing.md
@@ -46,8 +46,8 @@ Use the [new-project](https://github.com/saucelabs/new-project) template as a bo
     - How to run and write tests
     - How to write documentation or, if applicable, how to generate it
     - A list of requirements to contribute a patch (this could also be described in a pull request [template](https://help.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates))
-- Include a CODE_OF_CONDUCT.md file with guidelines that establish expectations for behavior by participants (maintainers, contributors, users) working on your project (only necessary if your project has custom wording as our default [CODE_OF_CONDUCT.md](https://github.com/saucelabs/.github/blob/master/CODE_OF_CONDUCT.md))
-- Include a SECURITY.md file (only necessary if your project has special requirements for security escalations as we have a default [SECURITY.md](https://github.com/saucelabs/.github/blob/master/SECURITY.md) for all projects)
+- Include a CODE_OF_CONDUCT.md file with guidelines that establish expectations for behavior by participants (maintainers, contributors, users) working on your project (only necessary if your project has custom wording different from our default [CODE_OF_CONDUCT.md](https://github.com/saucelabs/.github/blob/master/CODE_OF_CONDUCT.md))
+- Include a SECURITY.md file (only necessary if your project has special requirements for security escalations compared to our default [SECURITY.md](https://github.com/saucelabs/.github/blob/master/SECURITY.md) for all projects)
 - Add a LICENSE.md file; the license must be MIT with the copyright attributed to Sauce Labs
 - Ensure you only use license-compatible code/dependencies (see [licensing](/docs/license-guide/))
 


### PR DESCRIPTION
Going over the existing OSS projects I recognised some things we could change in our guidelines:

- Requiring to have a Maintainers.md file is very error prone as no one updates it which can rather confuse than help at the end. I added a [`SUPPORT.md`](https://github.com/saucelabs/.github/blob/master/SUPPORT.md) file to our community health files with information on how to contact is specific cases - it is automatically applied to all projects. That said, there is of course no problem if the team decides to add such an file to their project.
- It is not required anymore to have a CoC within the repo as [we have one](https://github.com/saucelabs/.github/blob/master/CODE_OF_CONDUCT.md) in the community health repository
- same for `Security.md`