### PR TITLE
Refining wording and moving section down

### DIFF
--- a/data/homepage.yml
+++ b/data/homepage.yml
@@ -181,8 +181,8 @@ portfolio:
 open_sauce_projects:
   enable: true
   title: "Projects"
-  heading: "Active Projects on Open Sauce"
-  intro: "Sauce Labs is committed to support the open source ecosystem by providing free licenses."
+  heading: "Open Source projects we support"
+  intro: "Sauce Labs is committed to support the open source ecosystem by providing free licenses through the Open Sauce program."
   item:
     - name: "Nuxt"
       image: "images/logos/nuxt.png"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -58,12 +58,6 @@
   {{ end }}
   {{ end }}
 
-  {{ if .Site.Data.homepage.open_sauce_projects.enable }}
-  {{ with .Site.Data.homepage.open_sauce_projects }}
-  {{ partial "projects.html" . }}
-  {{ end }}
-  {{ end }}
-
   {{ if .Site.Data.about.team.enable }}
   {{ with .Site.Data.about.team }}
   {{ partial "team.html" . }}
@@ -79,6 +73,12 @@
   {{ if .Site.Data.homepage.events.enable }}
   {{ with .Site.Data.homepage.events }}
   {{ partial "events.html" . }}
+  {{ end }}
+  {{ end }}
+
+  {{ if .Site.Data.homepage.open_sauce_projects.enable }}
+  {{ with .Site.Data.homepage.open_sauce_projects }}
+  {{ partial "projects.html" . }}
   {{ end }}
   {{ end }}
 

--- a/static/sass/modules/events.scss
+++ b/static/sass/modules/events.scss
@@ -1,6 +1,4 @@
 .events {
-    background-color: #EEE;
-
     &.max-height {
         min-height: 100%;
     }

--- a/static/sass/modules/involvement.scss
+++ b/static/sass/modules/involvement.scss
@@ -1,4 +1,6 @@
 .involvement {
+    background-color: #EEE;
+
     .section-title {
         margin-bottom: 0;
         padding-bottom: 20px;


### PR DESCRIPTION
This moves down the section with projects supported by Open Sauce and the wording has been updated so visitors don't mix projects in our GitHub org and projects supported by the Open Sauce program.