### PR TITLE
Script to add OneTrust cookies consent

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -32,6 +32,13 @@
   <link rel="apple-touch-icon" sizes="180x180" href="{{ `images/apple-touch-icon.png` | absURL }}">
   <link rel="mask-icon" color="{{ .Site.Params.theme_color }}" href="{{ `images/safari-pinned-tab.svg` | absURL }}">
 
+  <!-- OneTrust Cookies Consent Notice start for opensource.saucelabs.com -->
+  <script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="6d1eb79b-c89c-440f-87e8-dc9c37f0e44b" ></script>
+  <script type="text/javascript">
+    function OptanonWrapper() { }
+  </script>
+  <!-- OneTrust Cookies Consent Notice end for opensource.saucelabs.com -->
+
   {{ with .Site.Params.google_tag_manager_id }}
   <script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
   {{ end }}


### PR DESCRIPTION
Dear OSPO Team, 

In order to comply with privacy laws, Sauce Labs uses OneTrust services. 
Mike LeBaron is our main contact with OneTrust, and he gave me access to add the consent on our missing websites. 
It should be super straight forward, just add a script in the head of the main js file.
I am not sure if Hugo is considered a CMS... if so, this PR needs to be ignored o_o and we need to think together how to add it. There's also other instructions if you are using Google Tag Manager. If so, please let me know :)
This script uses Sauce Labs default consent, done by our legal team. But cookies can be recategorized if you need some specific in order to make certain features to work. 
I think this is not the case of OSPO... but if it is, please let me know :)

I am attaching the OneTrust Summary Scan, in case you want to see it.

[ScanResult_for_2021-11-25 12_38_53.093_opensource.saucelabs.com.xlsx.xlsx](https://github.com/saucelabs/saucelabs.github.io/files/7628008/ScanResult_for_2021-11-25.12_38_53.093_opensource.saucelabs.com.xlsx.xlsx)

![Screen Shot 2021-11-30 at 7 39 34 PM](https://user-images.githubusercontent.com/7980624/144107869-17fc1cac-5f14-478b-9f2d-f6027d9559df.png)
![Screen Shot 2021-11-30 at 7 39 23 PM](https://user-images.githubusercontent.com/7980624/144107874-fa561f1a-498f-48e4-abef-7332c2a2596e.png)


